### PR TITLE
Simulator parameters per test class

### DIFF
--- a/tests/opc-plc-tests/DataMonitoringTests.cs
+++ b/tests/opc-plc-tests/DataMonitoringTests.cs
@@ -9,7 +9,6 @@ namespace OpcPlc.Tests
     /// Tests for OPC-UA Monitoring for Data changes.
     /// </summary>
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class DataMonitoringTests : SubscriptionTestsBase
     {
         [SetUp]

--- a/tests/opc-plc-tests/EventMonitoringTests.cs
+++ b/tests/opc-plc-tests/EventMonitoringTests.cs
@@ -10,10 +10,13 @@ namespace OpcPlc.Tests
     /// Tests for OPC-UA Monitoring for Events.
     /// </summary>
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class EventMonitoringTests : SubscriptionTestsBase
     {
         private NodeId _eventType;
+
+        public EventMonitoringTests() : base(new[] { "--simpleevents" })
+        {
+        }
 
         [SetUp]
         public void CreateMonitoredItem()

--- a/tests/opc-plc-tests/MonitoringTestsBase.cs
+++ b/tests/opc-plc-tests/MonitoringTestsBase.cs
@@ -15,7 +15,6 @@ namespace OpcPlc.Tests
     /// Abstract base class for tests using OPC-UA Subscriptions.
     /// </summary>
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public abstract class SubscriptionTestsBase : SimulatorTestsBase
     {
         /// <summary>
@@ -26,6 +25,10 @@ namespace OpcPlc.Tests
         private Subscription _subscription;
 
         private readonly ConcurrentQueue<MonitoredItemNotificationEventArgs> _receivedEvents = new ConcurrentQueue<MonitoredItemNotificationEventArgs>();
+
+        protected SubscriptionTestsBase(string[] args = default) : base(args)
+        {
+        }
 
         /// <summary>
         /// Creates the subscription.

--- a/tests/opc-plc-tests/README.md
+++ b/tests/opc-plc-tests/README.md
@@ -1,7 +1,7 @@
 # OPC PLC server tests
 This project contains integration tests.
 
-The test fixture runs a singleton instance of the OPC PLC Server as a background thread, and performs test from the client side.
+The test fixture runs an instance of the OPC PLC Server per test class, as a background thread, and performs test from the client side.
 
 The Server is instrumented with mocks for time-related objects and methods (DateTime.Now, Timers) so
 that time can be controlled programmatically.

--- a/tests/opc-plc-tests/SimulatorNodesTests.cs
+++ b/tests/opc-plc-tests/SimulatorNodesTests.cs
@@ -11,7 +11,6 @@ namespace OpcPlc.Tests
     /// Tests for the variables defined in the simulator, such as fast-changing and trended nodes.
     /// </summary>
     [TestFixture]
-    [Parallelizable(ParallelScope.None)]
     public class SimulatorNodesTests : SimulatorTestsBase
     {
         // Simulator does not update trended and boolean values in the first few cycles (a random number of cycles between 1 and 10)

--- a/tests/opc-plc-tests/VariableTests.cs
+++ b/tests/opc-plc-tests/VariableTests.cs
@@ -9,10 +9,13 @@ namespace OpcPlc.Tests
     /// Tests for interacting with OPC-UA Variable nodes.
     /// </summary>
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class VariableTests : SimulatorTestsBase
     {
         private NodeId _scalarStaticNode;
+
+        public VariableTests() : base(new[] { "--ref" })
+        {
+        }
 
         [SetUp]
         public void SetUp()


### PR DESCRIPTION
## Purpose
* Run a different simulator process for each test class, allowing the test class to specify different simulator arguments. For example, `EventMonitoringTests` runs the simulator with the `--simpleevents` argument, while `VariableTests` runs the simulator with the `--ref` argument.
* This will allow testing various settings when parameterizing the simulator, and avoid test interference when doing so.
* To support this, tests are not run in parallel anymore, but sequentially. The run is still very fast, so it should not be a problem. We can still parallelize methods within one class (with `[Parallelizable]`), and in the future we can also run simulators concurrently on different ports to parallelize classes if desired.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```