### PR TITLE
Added negative range for double sequential value changes, removed com…

### DIFF
--- a/src/PlcNodeManager.cs
+++ b/src/PlcNodeManager.cs
@@ -360,7 +360,7 @@ namespace OpcPlc
                 Logger.Warning("Invalid argument {argument} provided.", nodes);
                 return;
             }
-            
+
             for (int nodeIndex = 0; nodeIndex < nodes.Length; nodeIndex++)
             {
                 var extendedNode = (BaseDataVariableStateExtended)nodes[nodeIndex];
@@ -404,9 +404,17 @@ namespace OpcPlc
                                                  ? minDoubleValue
                                                      : ((extendedDoubleNodeValue % maxDoubleValue) + (double)extendedNode.StepSize);
                                 }
+                                else if (maxDoubleValue <= 0 && minDoubleValue < 0) // Negative only range cases (e.g. 0 to -9.5).
+                                {
+                                    value = (extendedDoubleNodeValue % minDoubleValue) > maxDoubleValue
+                                    ? maxDoubleValue
+                                     : ((extendedDoubleNodeValue % minDoubleValue) - (double)extendedNode.StepSize) < minDoubleValue
+                                                 ? maxDoubleValue
+                                                 : (extendedDoubleNodeValue % minDoubleValue) - (double)extendedNode.StepSize;
+                                }
                                 else
                                 {
-                                    throw new ArgumentException($"Negative range {minDoubleValue} to {maxDoubleValue} for sequential node values is not supported currently.");
+                                    throw new ArgumentException($"Negative to positive range {minDoubleValue} to {maxDoubleValue} for sequential node values is not supported currently.");
                                 }
                             }
                             break;

--- a/tests/opc-plc-tests/DataRandomizationTests.cs
+++ b/tests/opc-plc-tests/DataRandomizationTests.cs
@@ -15,6 +15,9 @@
     [Parallelizable(ParallelScope.All)]
     public class DataRandomizationTests : SubscriptionTestsBase
     {
+        public DataRandomizationTests() : base(new[] { "--str=true", "--sr=2" })
+        { }
+
         [SetUp]
         public void CreateMonitoredItem()
         {
@@ -31,9 +34,9 @@
             // Arrange
             ClearEvents();
 
-            // Act: collect events during 50 seconds
-            // Value is updated every 10 seconds
-            FireTimersWithPeriod(10000, 5);
+            // Act: collect events during 10 seconds
+            // Value is updated every 2 seconds
+            FireTimersWithPeriod(2000, 5);
 
             // Assert
             var events = ReceiveEvents(6);

--- a/tests/opc-plc-tests/PlcSimulatorFixture.cs
+++ b/tests/opc-plc-tests/PlcSimulatorFixture.cs
@@ -88,9 +88,7 @@ namespace OpcPlc.Tests
             mock.Setup(f => f.UtcNow())
                 .Returns(() => _now);
 
-            // The simulator program command line.
-            // Currently, we do not support multiple instances of PLC server in test framework hence we are limited to use mutually exclusive cmd line parameters
-            // This prevents us from using random flag as it will make other tests fail which are using sequential values for nodes.
+            // The simulator program command line.            
             _serverTask = Task.Run(() => Program.MainAsync(_args.Concat(new[] { "--autoaccept" }).ToArray(), _serverCancellationTokenSource.Token).GetAwaiter().GetResult());
 
             var endpointUrl = WaitForServerUp();


### PR DESCRIPTION
## Purpose
* Added negative range sequential node value update for double type.
* Updated integration test to use multi instance plc + removed stale comment.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

